### PR TITLE
Add custom server join message

### DIFF
--- a/Cove/Server/Server.Packet.cs
+++ b/Cove/Server/Server.Packet.cs
@@ -30,7 +30,7 @@ namespace Cove.Server
 
                 case "new_player_join":
                     {
-                        if (!hideJoinMessage)
+                        if (!string.IsNullOrEmpty(joinMessage))
                         {
                             messagePlayer(joinMessage, sender);
                         }

--- a/Cove/Server/Server.Packet.cs
+++ b/Cove/Server/Server.Packet.cs
@@ -32,8 +32,7 @@ namespace Cove.Server
                     {
                         if (!hideJoinMessage)
                         {
-                            messagePlayer("This is a Cove dedicated server!", sender);
-                            messagePlayer("Please report any issues to the github (xr0.xyz/cove)", sender);
+                            messagePlayer(joinMessage, sender);
                         }
                         Dictionary<string, object> hostPacket = new();
                         hostPacket["type"] = "recieve_host";

--- a/Cove/Server/Server.cs
+++ b/Cove/Server/Server.cs
@@ -19,6 +19,7 @@ namespace Cove.Server
         public bool codeOnly = true;
         public bool ageRestricted = false;
         
+        public string joinMessage = "This is a Cove dedicated server!\nPlease report any issues to the github (xr0.xyz/cove)";
         public bool hideJoinMessage = false;
 
         public float rainMultiplyer = 1f;
@@ -121,6 +122,10 @@ namespace Cove.Server
 
                     case "hideJoinMessage":
                         hideJoinMessage = getBoolFromString(config[key]);
+                        break;
+
+                    case "joinMessage":
+                        joinMessage = config[key];
                         break;
 
                     case "spawnMeteor":

--- a/Cove/Server/Server.cs
+++ b/Cove/Server/Server.cs
@@ -20,7 +20,6 @@ namespace Cove.Server
         public bool ageRestricted = false;
         
         public string joinMessage = "This is a Cove dedicated server!\nPlease report any issues to the github (xr0.xyz/cove)";
-        public bool hideJoinMessage = false;
 
         public float rainMultiplyer = 1f;
         public bool shouldSpawnMeteor = true;
@@ -118,10 +117,6 @@ namespace Cove.Server
 
                     case "pluginsEnabled":
                         arePluginsEnabled = getBoolFromString(config[key]);
-                        break;
-
-                    case "hideJoinMessage":
-                        hideJoinMessage = getBoolFromString(config[key]);
                         break;
 
                     case "joinMessage":

--- a/Cove/server.cfg
+++ b/Cove/server.cfg
@@ -19,8 +19,12 @@ ageRestricted = false
 codeOnly = true
 
 # hide join message
-# if enabled will skip sending the "this is a cove dedicated server message"
+# if enabled will skip sending the configured join message
 hideJoinMessage = false
+
+# join message
+# Sets custom join message shown to players when they join the lobby
+joinMessage = "This is a Cove dedicated server!\nPlease report any issues to the github (xr0.xyz/cove)"
 
 # rain spawn multiplyer, incressing this number will increase the ammount he rain chance incresses each tick
 rainSpawnMultiplyer = 1

--- a/Cove/server.cfg
+++ b/Cove/server.cfg
@@ -24,7 +24,7 @@ hideJoinMessage = false
 
 # join message
 # Sets custom join message shown to players when they join the lobby
-joinMessage = "This is a Cove dedicated server!\nPlease report any issues to the github (xr0.xyz/cove)"
+#joinMessage = This is a Cove dedicated server! Please report any issues to the github (xr0.xyz/cove)
 
 # rain spawn multiplyer, incressing this number will increase the ammount he rain chance incresses each tick
 rainSpawnMultiplyer = 1

--- a/Cove/server.cfg
+++ b/Cove/server.cfg
@@ -18,10 +18,6 @@ ageRestricted = false
 # controls if the server appears as a public or code-only lobby
 codeOnly = true
 
-# hide join message
-# if enabled will skip sending the configured join message
-hideJoinMessage = false
-
 # join message
 # Sets custom join message shown to players when they join the lobby
 #joinMessage = This is a Cove dedicated server! Please report any issues to the github (xr0.xyz/cove)


### PR DESCRIPTION
Gives users the ability to set a custom join message in the server config, useful in cases where a unique message based on the server usecase would be useful (e.g. suggestion for using antilag mod on 50 player servers)