### PR TITLE
Localization fix in WorldFile loader

### DIFF
--- a/Cove/Server/Utils/WorldFile.cs
+++ b/Cove/Server/Utils/WorldFile.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Globalization;
+using System.Text.RegularExpressions;
 using Cove.GodotFormat;
 
 namespace Cove.Server.Utils
@@ -27,7 +28,7 @@ namespace Cove.Server.Utils
                     string y = match.Groups[2].Value;
                     string z = match.Groups[3].Value;
 
-                    Vector3 thisPoint = new Vector3(float.Parse(x), float.Parse(y), float.Parse(z));
+                    Vector3 thisPoint = new Vector3(float.Parse(x, CultureInfo.InvariantCulture), float.Parse(y, CultureInfo.InvariantCulture), float.Parse(z, CultureInfo.InvariantCulture));
                     points.Add(thisPoint);
                 }
             }


### PR DESCRIPTION
when i tried to run the project in visual studio, i stumbled upon the error shown below.
float.Parse() expected a comma in string, not a dot. probably due to my locale (pl_PL).
fixed it by applying CultureInfo.InvariantCulture as a second argument in float parser.

![fix](https://github.com/user-attachments/assets/64c8c348-6331-4cca-8bd9-74fc81bcf4c4)