### PR TITLE
Add more illegal actors and format actor detection

### DIFF
--- a/Cove/Server/Server.Packet.cs
+++ b/Cove/Server/Server.Packet.cs
@@ -77,7 +77,7 @@ namespace Cove.Server
                         long actorID = (long)((Dictionary<string, object>)packetInfo["params"])["actor_id"];
 
                         // all actor types that should not be spawned by anyone but the server!
-                        string[] illegalTypes = ["fish_spawn_alien", "fish_spawn", "raincloud", "canvas", "ambient_bird", "void_portal"];
+                        string[] illegalTypes = ["fish_spawn_alien", "fish_spawn", "raincloud", "canvas", "ambient_bird", "void_portal", "metal_spawn"];
                         if (Array.LastIndexOf(illegalTypes, type) > -1)
                         {
                             WFPlayer offendingPlayer = AllPlayers.Find(p => p.SteamId.m_SteamID == sender.m_SteamID);

--- a/Cove/Server/Server.Packet.cs
+++ b/Cove/Server/Server.Packet.cs
@@ -77,7 +77,8 @@ namespace Cove.Server
                         long actorID = (long)((Dictionary<string, object>)packetInfo["params"])["actor_id"];
 
                         // all actor types that should not be spawned by anyone but the server!
-                        if (type == "fish_spawn_alien" || type == "fish_spawn" || type == "raincloud")
+                        string[] illegalTypes = ["fish_spawn_alien", "fish_spawn", "raincloud", "canvas", "ambient_bird", "void_portal"];
+                        if (Array.LastIndexOf(illegalTypes, type) > -1)
                         {
                             WFPlayer offendingPlayer = AllPlayers.Find(p => p.SteamId.m_SteamID == sender.m_SteamID);
 


### PR DESCRIPTION
Adds more illegal actors that players can not spawn:
**Canvas** - unused actor ingame used for abuse
**Ambient Bird** - supposed to be spawned by server only
**Void Portal, Metal Spawn** - should only be spawned by server only

I also improved the code to be formatted better.