### PR TITLE
"spawn" command error handling

### DIFF
--- a/Cove.ChatCommands/ChatCommands.cs
+++ b/Cove.ChatCommands/ChatCommands.cs
@@ -54,6 +54,11 @@ public class ChatCommands : CovePlugin
         RegisterCommand("spawn", (player, args) =>
         {
             if (!IsPlayerAdmin(player)) return;
+            if (args.Length == 0)
+            {
+                SendPlayerChatMessage(player, "You didn't add an argument!")
+                return;
+            }
             var actorType = args[0].ToLower();
             bool spawned = false;
             switch (actorType)


### PR DESCRIPTION
Hi, I run my own cove server and when messing around with commands, I typed "spawn" without any arguments. This caused the server to crash. I thought this could definitely cause issues with other people, especially when they rely on the server to be reliable, so I fixed it!

My fix involves adding a simple if statement that checks if the args array has at least one parameter. If there's at least one parameter, it goes on like usual. Otherwise, it says the issue to the user and returns the code. This prevents someone from adding no args and the server checking for args[0].

I really hope this is helpful, as I love this piece of software.

Thanks,
Monika