### PR TITLE
Feat: ban reasons

### DIFF
--- a/Cove/Server/Plugins/CovePlugin.cs
+++ b/Cove/Server/Plugins/CovePlugin.cs
@@ -24,8 +24,14 @@ namespace Cove.Server.Plugins
         public virtual void onPlayerJoin(WFPlayer player) { }
         // triggered when a player leaves the server
         public virtual void onPlayerLeave(WFPlayer player) { }
-        // triggered when a packet arrives
-        public virtual void onNetworkPacket(WFPlayer sender, Dictionary<string, object> packet) { }
+        /// <summary>
+        /// Triggered when a player is banned from the server
+        /// </summary>
+        /// <param name="player">If unknown, this will be an empty string</param>
+        /// <param name="reason">If not given, this will be an empty string</param>
+        public virtual void onPlayerBanned(WFPlayer player, string reason) { }
+		// triggered when a packet arrives
+		public virtual void onNetworkPacket(WFPlayer sender, Dictionary<string, object> packet) { }
 
         public WFPlayer[] GetAllPlayers()
         {

--- a/Cove/Server/Plugins/CovePlugin.cs
+++ b/Cove/Server/Plugins/CovePlugin.cs
@@ -75,15 +75,9 @@ namespace Cove.Server.Plugins
             ParentServer.kickPlayer(player.SteamId);
         }
 
-        public void BanPlayer(WFPlayer player)
+        public void BanPlayer(WFPlayer player, string reason = "")
         {
-            if (ParentServer.isPlayerBanned(player.SteamId))
-            {
-                ParentServer.banPlayer(player.SteamId);
-            } else
-            {
-                ParentServer.banPlayer(player.SteamId, true); // save to file if they are not already in there!
-            }
+            ParentServer.banPlayer(player.SteamId, !ParentServer.isPlayerBanned(player.SteamId), reason);
         }
 
         public void Log(string message)

--- a/Cove/Server/Server.Commands.cs
+++ b/Cove/Server/Server.Commands.cs
@@ -199,7 +199,7 @@ namespace Cove.Server
                     }
                 }
             );
-            SetCommandDescription("ban", "Bans a player from the server");
+            SetCommandDescription("ban", "Usage: !ban (username|steamID|FisherID) \"Reason for ban\"");
 
             RegisterCommand("prev", (player, args) =>
             {

--- a/Cove/Server/Server.Commands.cs
+++ b/Cove/Server/Server.Commands.cs
@@ -196,9 +196,6 @@ namespace Cove.Server
                             !isPlayerBanned(playerToBan.SteamId),
                             banReason
                         );
-
-                        messagePlayer($"Banned {playerToBan.Username}", player.SteamId);
-                        messageGlobal($"{playerToBan.Username} has been banned from the server");
                     }
                 }
             );

--- a/Cove/Server/Server.Punish.cs
+++ b/Cove/Server/Server.Punish.cs
@@ -27,9 +27,9 @@ namespace Cove.Server
 {
     public partial class CoveServer
     {
-
-        public void banPlayer(CSteamID id, bool saveToFile = false)
+        public void banPlayer(CSteamID id, bool saveToFile = false, string banReason = "")
         {
+
             Dictionary<string, object> banPacket = new();
             banPacket["type"] = "client_was_banned";
             sendPacketToPlayer(banPacket, id);
@@ -40,7 +40,7 @@ namespace Cove.Server
             sendPacketToPlayers(leftPacket);
 
             if (saveToFile)
-                writeToBansFile(id);
+                writeToBansFile(id, banReason);
 
             sendBlacklistPacketToAll(id.m_SteamID.ToString());
         }
@@ -61,12 +61,14 @@ namespace Cove.Server
             return false;
         }
 
-        private void writeToBansFile(CSteamID id)
+        private void writeToBansFile(CSteamID id, string reason)
         {
-            string fileDir = $"{AppDomain.CurrentDomain.BaseDirectory}bans.txt";
-            PreviousPlayer player = PreviousPlayers.Find(p => p.SteamId == id);
-            string username = player != null ? player.Username : "Unknown";
-            File.AppendAllLines(fileDir, [$"{id.m_SteamID} #{username}"]);
+            string entry = $"{id.m_SteamID} # ";
+            string username = PreviousPlayers.Find(p => p.SteamId == id)?.Username ?? "Unknown";
+            entry += username;
+            if (!string.IsNullOrEmpty(reason))
+                entry += $" - {reason}";
+            File.AppendAllLines($"{AppDomain.CurrentDomain.BaseDirectory}bans.txt", [entry]);
         }
 
         public void kickPlayer(CSteamID id)

--- a/Cove/Server/Server.Punish.cs
+++ b/Cove/Server/Server.Punish.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Cove.Server.Actor;
+using Cove.Server.Plugins;
 using Steamworks;
 
 namespace Cove.Server
@@ -29,6 +30,7 @@ namespace Cove.Server
     {
         public void banPlayer(CSteamID id, bool saveToFile = false, string banReason = "")
         {
+            var player = new WFPlayer(id, Steamworks.SteamFriends.GetFriendPersonaName(id), new SteamNetworkingIdentity());
 
             Dictionary<string, object> banPacket = new();
             banPacket["type"] = "client_was_banned";
@@ -38,6 +40,12 @@ namespace Cove.Server
             leftPacket["type"] = "peer_was_banned";
             leftPacket["user_id"] = (long)id.m_SteamID;
             sendPacketToPlayers(leftPacket);
+
+
+            foreach (PluginInstance plugin in loadedPlugins)
+            {
+                plugin.plugin.onPlayerBanned(player, banReason);
+            }
 
             if (saveToFile)
                 writeToBansFile(id, banReason);


### PR DESCRIPTION
I wanted to try and get mail working in order to provide users with a reason for their having been kicked/banned from a Cove server.

I was hoping I could help look into why -as you describe in the comments- sending letters causes clients to crash, if that is still an issue you are wanting to tackle. (For this and other purposes 🐬 ) 

I figured, if there is a large roadblock preventing the implementation of letter sending, perhaps ban-reasons can still be collected as part of admin logging.


- New Features
  - Added support for including a reason when banning a player.
  - Ban logs now record the provided reason alongside the player's username.
  - `onPlayerBanned` hook for plugins

- Fixes
  - Feedback for ambiguous or not-found targets; guidance provided when a leading “#” is required. Fixes #63

- Refactor
  - Streamlined ban flow and messaging


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Ban command now supports an optional quoted reason (e.g., !ban username "Reason").
  - Smarter target resolution: accepts SteamID, username, or FisherID; can fall back to previous players.
  - Clearer feedback for invalid or ambiguous targets.
  - Bans are logged with the associated reason when provided.
- Documentation
  - Updated ban command usage description to include reason parameter and accepted target formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->