### PR TITLE
1.4.12

### DIFF
--- a/Cove/Server/Plugins/CovePlugin.cs
+++ b/Cove/Server/Plugins/CovePlugin.cs
@@ -40,7 +40,7 @@ namespace Cove.Server.Plugins
 
         public void SendPlayerChatMessage(WFPlayer receiver, string message)
         {
-            // remove a # incase its given
+            // remove a # in case its given
             ParentServer.messagePlayer(message, receiver.SteamId);
         }
 

--- a/Cove/Server/Server.Commands.cs
+++ b/Cove/Server/Server.Commands.cs
@@ -208,7 +208,7 @@ namespace Cove.Server
                     // get the time since the player left in a human readable format
                     string timeLeft =
                         $"{Math.Round((DateTime.UtcNow - DateTimeOffset.FromUnixTimeSeconds(prevPlayer.leftTimestamp).UtcDateTime).TotalMinutes)} minutes ago";
-                    sb.Append($"{prevPlayer.Username} ({prevPlayer.FisherID}) - Left: {timeLeft}\n");
+                    sb.Append($"{prevPlayer.Username} [{prevPlayer.SteamId.ToString()}] ({prevPlayer.FisherID}) - Left: {timeLeft}\n");
                 }
                 messagePlayer(sb.ToString(), player.SteamId);
             });

--- a/Cove/Server/Server.Punish.cs
+++ b/Cove/Server/Server.Punish.cs
@@ -29,7 +29,7 @@ namespace Cove.Server
     public partial class CoveServer
     {
         
-        private static readonly object banLock = new();
+        private static readonly object BanLock = new();
         
         public void banPlayer(CSteamID id, bool saveToFile = false, string banReason = "")
         {
@@ -60,7 +60,7 @@ namespace Cove.Server
         {
             string fileDir = $"{AppDomain.CurrentDomain.BaseDirectory}bans.txt";
 
-            lock (banLock)
+            lock (BanLock)
             {
                 // check if the file exists
                 if (!File.Exists(fileDir))
@@ -90,7 +90,7 @@ namespace Cove.Server
             if (!string.IsNullOrEmpty(reason))
                 entry += $" - {reason}";
             // check if the file is already opened by another process
-            lock (banLock)
+            lock (BanLock)
             {
                 try
                 {


### PR DESCRIPTION
Lock ban file to prevent crashes
Log SteamIDs with !prev, fixes #75 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Previous players list now displays SteamID alongside Username and FisherID for clearer identification.
* **Bug Fixes**
  * Improved reliability of ban checks and updates during concurrent access, reducing potential file errors and ensuring consistent behavior when the bans list is missing or being modified.
* **Documentation**
  * Corrected a minor comment typo; no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->