### PR TITLE
Fix/chalk desync

### DIFF
--- a/Cove/Server/Chalk/ChalkCanvas.cs
+++ b/Cove/Server/Chalk/ChalkCanvas.cs
@@ -1,9 +1,10 @@
 ﻿using System.Numerics;
+using Steamworks;
 using Vector2 = Cove.GodotFormat.Vector2;
 
 namespace Cove.Server.Chalk
 {
-    internal enum COLOR : long
+    public enum COLOR : long
     {
         BLACK,
         WHITE,
@@ -27,7 +28,12 @@ namespace Cove.Server.Chalk
             this.server = server;
         }
 
-        private void drawChalk(Dictionary<int, object> transformations)
+        /// <summary>
+        /// Update the chalk canvas image with the given transformations
+        /// </summary>
+        /// <param name="transformations">A dictionary containing the transformations, where each key is an index and each value is a dictionary containing a position (Vector2) and a color (long).</param>
+        /// <remarks>Only canvases with IDs {0, 1, 2, 3} are allowed to be updated.</remarks>
+        private void updateCanvasImage(Dictionary<int, object> transformations)
         {
             int[] allowedCanvas = { 0, 1, 2, 3 };
             if (!Array.Exists(allowedCanvas, element => element == canvasID))
@@ -36,58 +42,47 @@ namespace Cove.Server.Chalk
                 return;
             }
 
-            var chalkData = new Dictionary<int, object>();
-            for (int i = 0; i < transformations.Count; i++)
+            foreach (var idx in transformations.Keys)
             {
-                var transformation = (Dictionary<int, object>)transformations[i];
+                var transformation = (Dictionary<int, object>)transformations[idx];
                 var coords = (Vector2)transformation[0];
                 var color = (long)transformation[1];
                 chalkImage[coords] = color;
-                chalkData[i] = new Dictionary<int, object> { { 0, coords }, { 1, color } };
             }
-
-            server.sendPacketToPlayers(
-                new Dictionary<string, object>
-                {
-                    { "type", "chalk_packet" },
-                    { "canvas_id", canvasID },
-                    { "data", chalkData },
-                    { "channel", 3 },
-                }
-            );
         }
 
         /// <summary>
-        /// Generate a packet containing the canvas chalk data
+        /// Generate chalkData from the canvas image for use in a chalk_update packet
         /// </summary>
         /// <returns>A dictionary containing the chalk data.</returns>
+        /// <remarks>If caller is going to broadcast the chalkData consider using ChalkCanvas.emitChalk instead.</remarks>
         public Dictionary<int, object> getChalkPacket()
         {
-            Dictionary<int, object> packet = new Dictionary<int, object>();
+            Dictionary<int, object> cells = new Dictionary<int, object>();
             ulong i = 0;
             foreach (KeyValuePair<Vector2, long> entry in chalkImage.ToList())
             {
                 Dictionary<int, object> arr = new();
                 arr[0] = entry.Key;
                 arr[1] = entry.Value;
-                packet[(int)i] = arr;
+                cells[(int)i] = arr;
                 i++;
             }
-
-            return packet;
+            return cells;
         }
 
         /// <summary>
-        /// Update the chalk canvas image
+        /// Update the chalk canvas image, without broadcasting the change
         /// </summary>
         /// <param name="chalkData">A dictionary containing the chalk data, where each key is an index and each value is a dictionary containing a position (Vector2) and a color (long).</param>
+        /// <remarks>This is meant to be called only by the server when handling incoming chalk packets...</remarks>
         public void chalkUpdate(Dictionary<int, object> chalkData)
         {
-            this.drawChalk(chalkData);
+            this.updateCanvasImage(chalkData);
         }
 
         /// <summary>
-        /// Copy/paste chalkData onto the chalk canvas
+        /// Copy/paste some existing chalkData onto the chalk canvas and broadcast the change
         /// </summary>
         /// <param name="chalkData"></param>
         public void chalkUpdate(Dictionary<Vector2, long> chalkData)
@@ -96,7 +91,7 @@ namespace Cove.Server.Chalk
             {
                 var position = transformation.Key;
                 var color = transformation.Value;
-                this.drawChalk(
+                this.updateCanvasImage(
                     new Dictionary<int, object>
                     {
                         {
@@ -105,16 +100,17 @@ namespace Cove.Server.Chalk
                         },
                     }
                 );
+                emitChalk();
             }
         }
 
         /// <summary>
-        /// Update a single chalk canvas cell
+        /// Update a single chalk canvas cell, without broadcasting the change
         /// </summary>
         /// <param name="chalkData">A dictionary containing the chalk data, where each key is an index and each value is a dictionary containing a position (Vector2) and a color (long).</param>
         public void chalkUpdate(Vector2 position, long color)
         {
-            this.drawChalk(
+            this.updateCanvasImage(
                 new Dictionary<int, object>
                 {
                     {
@@ -126,22 +122,105 @@ namespace Cove.Server.Chalk
         }
 
         /// <summary>
-        /// Clear the chalk canvas
+        /// Clear the chalk canvas and optionally broadcast the change
         /// </summary>
         /// <param name="emitChanges">Whether to emit the changes to players. Default: true</param>
         public void clearCanvas(bool emitChanges = true)
         {
-            if (emitChanges)
-        {
-                var transformations = getChalkPacket();
-                for (int i = 0; i < transformations.Count; i++)
-                {
-                    var cell = (Dictionary<int, object>)transformations[i];
-                    cell[1] = COLOR.NONE;
-                }
-                drawChalk(transformations);
+            var transformations = getChalkPacket();
+            for (int i = 0; i < transformations.Count; i++)
+            {
+                var cell = (Dictionary<int, object>)transformations[i];
+                cell[1] = COLOR.NONE;
             }
-            chalkImage.Clear();
+            drawChalk(transformations);
+            if (emitChanges)
+            {
+                emitChalk();
+            }
+        }
+
+        /// <summary>
+        /// Draw and broadcast given chalk updates
+        /// </summary>
+        /// <param name="transformations"></param>
+        public void drawChalk(Dictionary<int, object> transformations)
+        {
+            updateCanvasImage(transformations);
+            var cells = new List<Dictionary<int, object>>();
+            foreach (var idx in transformations.Keys)
+            {
+                var transformation = (Dictionary<int, object>)transformations[idx];
+                var coords = (Vector2)transformation[0];
+                var color = (long)transformation[0];
+                cells.Append(new Dictionary<int, object> { { 0, coords }, { 1, color } });
+            }
+            var chalkData = new Dictionary<int, object>();
+            for (int i = 0; i < cells.Count; i++)
+            {
+                chalkData[i] = cells[i];
+            }
+            server.sendPacketToPlayers(
+                new Dictionary<string, object>
+                {
+                    { "type", "chalk_packet" },
+                    { "canvas_id", canvasID },
+                    { "data", chalkData },
+                    { "channel", (int)Server.CHANNELS.CHALK },
+                }
+            );
+        }
+
+        /// <summary>
+        /// Broadcast the current chalk canvas
+        /// </summary>
+        /// <param name="omitEmptyCells">Whether to omit empty cells</param>
+        /// <param name="recipient">Optional recipient, defaults to all players</param>
+        public void emitChalk(bool omitEmptyCells = false, CSteamID? recipient = null)
+        {
+            Dictionary<int, object> chalkData = getChalkPacket();
+
+            if (omitEmptyCells)
+            {
+                Dictionary<int, object> allChalk = chalkData;
+                List<Dictionary<int, object>> nonEmptyChalk = new();
+                foreach (var idx in allChalk.Keys)
+                {
+                    var cell = (Dictionary<int, object>)allChalk[idx];
+                    bool isEmpty = (long)cell[1] == (long)Chalk.COLOR.NONE;
+                    if (!isEmpty)
+                    {
+                        // Removing empty cells from allChalk would break indexing
+                        // of the 'pseudoarray' so we have to create a new list
+                        // TODO: Helper function to recreate non-ordered Dictionary
+                        nonEmptyChalk.Add(cell);
+                    }
+                }
+                chalkData = new Dictionary<int, object>();
+                // Convert List to Dictionary for transmission
+                // TODO: Helper to convert List to pseudoarray Dictionary
+                for (int i = 0; i < nonEmptyChalk.Count; i++)
+                {
+                    chalkData[i] = nonEmptyChalk[i];
+                }
+            }
+
+            var packet = new Dictionary<string, object>
+            {
+                { "type", "chalk_packet" },
+                { "canvas_id", canvasID },
+                { "data", chalkData },
+                { "channel", (int)Server.CHANNELS.CHALK },
+            };
+
+            if (recipient?.GetType() == typeof(CSteamID))
+            {
+                server.sendPacketToPlayer(packet, (CSteamID)recipient);
+            }
+            else
+            {
+                server.sendPacketToPlayers(packet);
+            }
         }
     }
 }

--- a/Cove/Server/Server.Packet.cs
+++ b/Cove/Server/Server.Packet.cs
@@ -253,6 +253,7 @@ namespace Cove.Server
                             { "type", "chalk_packet" },
                             { "canvas_id", canvas.canvasID },
                             { "data", chunks[index] },
+                            { "channel", (int)Cove.Server.CHANNELS.CHALK },
                         };
                         sendPacketToPlayer(chalkPacket, recipient);
                         Thread.Sleep(10);

--- a/Cove/Server/Server.Packet.cs
+++ b/Cove/Server/Server.Packet.cs
@@ -225,39 +225,8 @@ namespace Cove.Server
                 // send the player all the canvas data
                 foreach (Chalk.ChalkCanvas canvas in chalkCanvas)
                 {
-                    Dictionary<int, object> allChalk = canvas.getChalkPacket();
-
-                    // split the dictionary into chunks of 100
-                    List<Dictionary<int, object>> chunks = new List<Dictionary<int, object>>();
-                    Dictionary<int, object> chunk = new Dictionary<int, object>();
-
-                    int i = 0;
-                    foreach (var kvp in allChalk)
-                    {
-                        if (i >= 1000)
-                        {
-                            chunks.Add(chunk);
-                            chunk = new Dictionary<int, object>();
-                            i = 0;
-                        }
-                        chunk.Add(i, kvp.Value);
-                        i++;
-                    }
-
-                    chunks.Add(chunk);
-
-                    for (int index = 0; index < chunks.Count; index++)
-                    {
-                        Dictionary<string, object> chalkPacket = new Dictionary<string, object>
-                        {
-                            { "type", "chalk_packet" },
-                            { "canvas_id", canvas.canvasID },
-                            { "data", chunks[index] },
-                            { "channel", (int)Cove.Server.CHANNELS.CHALK },
-                        };
-                        sendPacketToPlayer(chalkPacket, recipient);
-                        Thread.Sleep(10);
-                    }
+                    canvas.emitChalk(omitEmptyCells: true, recipient);
+                    Thread.Sleep(500);
                 }
             }
             catch (Exception e)

--- a/Cove/Server/Server.Utils.Networking.cs
+++ b/Cove/Server/Server.Utils.Networking.cs
@@ -24,7 +24,7 @@ using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Cove.Server
 {
-    enum CHANNELS : int
+    public enum CHANNELS : int
     {
         ACTOR_UPDATE,
         ACTOR_ACTION,
@@ -78,7 +78,7 @@ namespace Cove.Server
 
             int channel = packet.TryGetValue("channel", out object? value)
                 ? (int)value
-                : (int)CHANNELS.GAME_STATE;
+                : (int)Server.CHANNELS.GAME_STATE;
 
             SteamNetworkingMessages.SendMessageToUser(
                 ref player.identity,

--- a/Cove/Server/Server.Utils.Networking.cs
+++ b/Cove/Server/Server.Utils.Networking.cs
@@ -14,17 +14,27 @@
    limitations under the License.
 */
 
-
-using Steamworks;
-using Cove.GodotFormat;
-using Cove.Server.Utils;
-using Cove.Server.Actor;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using Cove.GodotFormat;
+using Cove.Server.Actor;
+using Cove.Server.Utils;
+using Steamworks;
 using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Cove.Server
 {
+    enum CHANNELS : int
+    {
+        ACTOR_UPDATE,
+        ACTOR_ACTION,
+        GAME_STATE,
+        CHALK,
+        GUITAR,
+        ACTOR_ANIMATION,
+        SPEECH,
+    }
+
     partial class CoveServer
     {
         Dictionary<string, object> readPacket(byte[] packetBytes)
@@ -45,7 +55,6 @@ namespace Cove.Server
                 if (player == SteamUser.GetSteamID())
                     continue;
 
-
                 sendPacketToPlayer(packet, player);
             }
         }
@@ -54,10 +63,10 @@ namespace Cove.Server
         {
             byte[] packetBytes = writePacket(packet);
 
-
             // get the wfPlayer object
             var player = AllPlayers.Find(p => p.SteamId.m_SteamID == id.m_SteamID);
-            if (player == null) return;
+            if (player == null)
+                return;
 
             if (player.identity.GetSteamID64() == 0)
             {
@@ -67,16 +76,9 @@ namespace Cove.Server
             GCHandle handle = GCHandle.Alloc(packetBytes, GCHandleType.Pinned);
             IntPtr dataPointer = handle.AddrOfPinnedObject();
 
-            // enum CHANNELS { 
-            //     ACTOR_UPDATE , 
-            //     ACTOR_ACTION , 
-            //     GAME_STATE , 
-            //     CHALK , 
-            //     GUITAR , 
-            //     ACTOR_ANIMATION , 
-            //     SPEECH , 
-            // } 
-            int channel = packet.ContainsKey("channel") ? (int)packet["channel"] : 2;
+            int channel = packet.TryGetValue("channel", out object? value)
+                ? (int)value
+                : (int)CHANNELS.GAME_STATE;
 
             SteamNetworkingMessages.SendMessageToUser(
                 ref player.identity,
@@ -85,7 +87,6 @@ namespace Cove.Server
                 8,
                 channel
             );
-
 
             handle.Free(); // free the handle
         }
@@ -109,6 +110,7 @@ namespace Cove.Server
         {
             public byte[] payload { get; set; }
             public int size { get; set; }
+
             //public CSteamID connection { get; set; }
             public ulong identity { get; set; }
             public ulong receiver_user_data { get; set; }
@@ -125,11 +127,17 @@ namespace Cove.Server
 
             nint[] messagePointers = new nint[maxMessages];
 
-            int availableMessages = SteamNetworkingMessages.ReceiveMessagesOnChannel(channel, messagePointers, maxMessages);
+            int availableMessages = SteamNetworkingMessages.ReceiveMessagesOnChannel(
+                channel,
+                messagePointers,
+                maxMessages
+            );
 
             for (int i = 0; i < availableMessages; i++)
             {
-                SteamNetworkingMessage_t message = Marshal.PtrToStructure<SteamNetworkingMessage_t>(messagePointers[i]);
+                SteamNetworkingMessage_t message = Marshal.PtrToStructure<SteamNetworkingMessage_t>(
+                    messagePointers[i]
+                );
 
                 byte[] data = new byte[message.m_cbSize];
                 Marshal.Copy(message.m_pData, data, 0, message.m_cbSize);
@@ -161,7 +169,7 @@ namespace Cove.Server
                     message_number = (ulong)message.m_nMessageNumber,
                     channel = message.m_nChannel,
                     flags = message.m_nFlags,
-                    sender_user_data = (ulong)message.m_nUserData
+                    sender_user_data = (ulong)message.m_nUserData,
                 };
 
                 messages.Add(msgDict);
@@ -176,7 +184,5 @@ namespace Cove.Server
         {
             return identity.GetSteamID64(); // Return 0 if no SteamID found
         }
-
     }
-
 }

--- a/Cove/Server/Server.Utils.Networking.cs
+++ b/Cove/Server/Server.Utils.Networking.cs
@@ -44,7 +44,8 @@ namespace Cove.Server
             {
                 if (player == SteamUser.GetSteamID())
                     continue;
-                
+
+
                 sendPacketToPlayer(packet, player);
             }
         }
@@ -52,7 +53,8 @@ namespace Cove.Server
         public void sendPacketToPlayer(Dictionary<string, object> packet, CSteamID id)
         {
             byte[] packetBytes = writePacket(packet);
-            
+
+
             // get the wfPlayer object
             var player = AllPlayers.Find(p => p.SteamId.m_SteamID == id.m_SteamID);
             if (player == null) return;
@@ -76,7 +78,14 @@ namespace Cove.Server
             // } 
             int channel = packet.ContainsKey("channel") ? (int)packet["channel"] : 2;
 
-            SteamNetworkingMessages.SendMessageToUser(ref player.identity, dataPointer, (uint)packetBytes.Length, 8, 2);
+            SteamNetworkingMessages.SendMessageToUser(
+                ref player.identity,
+                dataPointer,
+                (uint)packetBytes.Length,
+                8,
+                channel
+            );
+
 
             handle.Free(); // free the handle
         }


### PR DESCRIPTION
Fixes #94 - chalkUpdates get echoed unintentionally when `canvas.drawChalk` is being called from `chalk_update` handling. This leads to desync because the player who is drawing is always "drawing against" the server.

1. Refactors emission of chalking updates into separate methods - one for drawing and updating, and another to merely emit the entire canvas
2. Fixes chalk updates being broadcast on the "game state updates" (2) channel; fixes `sendPacketToPlayer` disregarding `channel` value of packet arg.
4. Chalk emission can now be performed without including empty cells. This is useful for cases like when a players has first joined.
5. This allows us to remove unnecessary (complexities of) batching in `SendStagedChalkPackets`which is not done in the vanilla client by hosts